### PR TITLE
Fixed "Player still walks and turns when no-clip is active"

### DIFF
--- a/Instructional_Buttons.lua
+++ b/Instructional_Buttons.lua
@@ -73,3 +73,19 @@ function setupScaleform(scaleform)
 
     return scaleform
 end
+
+function DisableControls()
+    DisableControlAction(0, 30, true)
+    DisableControlAction(0, 31, true)
+    DisableControlAction(0, 32, true)
+    DisableControlAction(0, 33, true)
+    DisableControlAction(0, 34, true)
+    DisableControlAction(0, 35, true)
+    DisableControlAction(0, 266, true)
+    DisableControlAction(0, 267, true)
+    DisableControlAction(0, 268, true)
+    DisableControlAction(0, 269, true)
+    DisableControlAction(0, 44, true)
+    DisableControlAction(0, 20, true)
+    DisableControlAction(0, 74, true)
+end

--- a/No-clip.lua
+++ b/No-clip.lua
@@ -88,28 +88,30 @@ Citizen.CreateThread(function()
                 end
                 setupScaleform("instructional_buttons")
             end
+				
+				DisableControls()
 
-			if IsControlPressed(0, config.controls.goForward) then
+			if IsDisabledControlPressed(0, config.controls.goForward) then
                 yoff = config.offsets.y
 			end
 			
-            if IsControlPressed(0, config.controls.goBackward) then
+            if IsDisabledControlPressed(0, config.controls.goBackward) then
                 yoff = -config.offsets.y
 			end
 			
-            if IsControlPressed(0, config.controls.turnLeft) then
+            if IsDisabledControlPressed(0, config.controls.turnLeft) then
                 SetEntityHeading(noclipEntity, GetEntityHeading(noclipEntity)+config.offsets.h)
 			end
 			
-            if IsControlPressed(0, config.controls.turnRight) then
+            if IsDisabledControlPressed(0, config.controls.turnRight) then
                 SetEntityHeading(noclipEntity, GetEntityHeading(noclipEntity)-config.offsets.h)
 			end
 			
-            if IsControlPressed(0, config.controls.goUp) then
+            if IsDisabledControlPressed(0, config.controls.goUp) then
                 zoff = config.offsets.z
 			end
 			
-            if IsControlPressed(0, config.controls.goDown) then
+            if IsDisabledControlPressed(0, config.controls.goDown) then
                 zoff = -config.offsets.z
 			end
 			


### PR DESCRIPTION
Disables controls so the player does not walk or turn, but the disable control still allows you to NoClip.